### PR TITLE
refactor(etapa-6): extract SanitizeTrait from controllers

### DIFF
--- a/Controller/SanitizeTrait.php
+++ b/Controller/SanitizeTrait.php
@@ -1,0 +1,9 @@
+<?php
+
+trait SanitizeTrait
+{
+    protected function sanitizeString(?string $string): string
+    {
+        return htmlspecialchars(strip_tags($string ?? ''), ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/Controller/cityController.php
+++ b/Controller/cityController.php
@@ -3,6 +3,8 @@ require_once './View/menuView.php';
 require_once './Model/cityModel.php';
 class cityController
 {
+    use SanitizeTrait;
+
     private $cityModel;
     private $cityView;
 
@@ -82,8 +84,4 @@ class cityController
         return $this->open('Cidade editada com sucesso!', $data);
     }
 
-    private function sanitizeString($string)
-    {
-        return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
-    }
 }

--- a/Controller/loginController.php
+++ b/Controller/loginController.php
@@ -5,6 +5,8 @@ require_once './View/cadUsuarioView.php';
 require_once './View/menuView.php';
 class loginController
 {
+    use SanitizeTrait;
+
     private $loginModel;
     private $menuView;
     private $userView;
@@ -51,8 +53,4 @@ class loginController
         $this->userView->formLogin($message);
     }
 
-    private function sanitizeString(?string $string): string
-    {
-        return htmlspecialchars(strip_tags($string ?? ''), ENT_QUOTES, 'UTF-8');
-    }
 }

--- a/Controller/ticketsController.php
+++ b/Controller/ticketsController.php
@@ -8,6 +8,8 @@ require_once './View/menuView.php';
 
 class ticketsController
 {
+    use SanitizeTrait;
+
     private $ticketModel;
     private $routeModel;
     private $ticketView;
@@ -75,8 +77,4 @@ class ticketsController
         return $this->ticketView->all($tickets);
     }
     
-    private function sanitizeString(?string $string): string
-    {
-        return htmlspecialchars(strip_tags($string ?? ''), ENT_QUOTES, 'UTF-8');
-    }
 }

--- a/Controller/userController.php
+++ b/Controller/userController.php
@@ -4,6 +4,8 @@ require_once './View/cadUsuarioView.php';
 
 class userController
 {
+    use SanitizeTrait;
+
     private $userModel;
     private $userView;
     public function __construct()
@@ -57,11 +59,6 @@ class userController
     private function checkPassword(string $password, string $confirmPassword): bool
     {
         return $password === $confirmPassword;
-    }
-    
-    private function sanitizeString(?string $string): string
-    {
-        return htmlspecialchars(strip_tags($string ?? ''), ENT_QUOTES, 'UTF-8');
     }
     
     private function hashPassword(string $password): string

--- a/Controller/vehicleController.php
+++ b/Controller/vehicleController.php
@@ -3,6 +3,8 @@ require_once './Model/vehicleModel.php';
 require_once './View/menuView.php';
 class vehicleController
 {
+    use SanitizeTrait;
+
     private $vehicleModel;
     private $vehicleView;
     
@@ -44,8 +46,4 @@ class vehicleController
         return $this->open('Veículo registrado com sucesso.', $data);
     }
     
-    private function sanitizeString(?string $string): string
-    {
-        return htmlspecialchars(strip_tags($string ?? ''), ENT_QUOTES, 'UTF-8');
-    }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,5 +2,18 @@
     "require": {
         "vlucas/phpdotenv": "^5.6",
         "firebase/php-jwt": "*"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    },
+    "autoload": {
+        "classmap": [
+            "Controller/SanitizeTrait.php"
+        ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+
+    <php>
+        <ini name="log_errors" value="0"/>
+    </php>
+
+    <source>
+        <include>
+            <file>Controller/SanitizeTrait.php</file>
+        </include>
+    </source>
+
+</phpunit>

--- a/tests/Unit/Controller/SanitizeTraitTest.php
+++ b/tests/Unit/Controller/SanitizeTraitTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use SanitizeTrait;
+
+class SanitizeTraitTest extends TestCase
+{
+    private object $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new class {
+            use SanitizeTrait;
+
+            public function sanitize(?string $s): string
+            {
+                return $this->sanitizeString($s);
+            }
+        };
+    }
+
+    public function testStripsHtmlTags(): void
+    {
+        $this->assertSame('hello', $this->subject->sanitize('<b>hello</b>'));
+    }
+
+    public function testStripsTagLeavingEmptyString(): void
+    {
+        // strip_tags remove a tag inteira — nada sobra para escapar
+        $this->assertSame('', $this->subject->sanitize('<script>'));
+    }
+
+    public function testEscapesAmpersand(): void
+    {
+        $this->assertSame('a &amp; b', $this->subject->sanitize('a & b'));
+    }
+
+    public function testEscapesDoubleQuotes(): void
+    {
+        $this->assertSame('say &quot;hi&quot;', $this->subject->sanitize('say "hi"'));
+    }
+
+    public function testEscapesSingleQuotes(): void
+    {
+        $this->assertSame('it&#039;s', $this->subject->sanitize("it's"));
+    }
+
+    public function testHandlesNullInput(): void
+    {
+        $this->assertSame('', $this->subject->sanitize(null));
+    }
+
+    public function testHandlesEmptyString(): void
+    {
+        $this->assertSame('', $this->subject->sanitize(''));
+    }
+
+    public function testPlainTextUnchanged(): void
+    {
+        $this->assertSame('São Paulo', $this->subject->sanitize('São Paulo'));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Muda o cwd para a raiz do projeto para que os require_once relativos
+ * dos models funcionem corretamente nos testes.
+ * Desativa error_log para evitar que PHPUnit capture stderr de processos
+ * isolados como erros de teste.
+ */
+chdir(dirname(__DIR__));
+
+ini_set('error_log', '/dev/null');
+
+require_once __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
## Summary
- Criado `Controller/SanitizeTrait.php` com `sanitizeString()` como `protected`
- Removida a implementação duplicada de `sanitizeString()` de 5 controllers (city, login, tickets, user, vehicle)
- Unificada a implementação — `cityController` tinha versão divergente sem `strip_tags`
- 8 testes unitários passando

## Test plan
- [ ] `SanitizeTraitTest` — 8 testes cobrindo: strip de tags, escape de `&`, `"`, `'`, null, string vazia, texto normal

🤖 Generated with [Claude Code](https://claude.com/claude-code)